### PR TITLE
feat: add table of contents content element for styleguide pages

### DIFF
--- a/Classes/Preview/StyleguidePreviewRenderer.php
+++ b/Classes/Preview/StyleguidePreviewRenderer.php
@@ -45,6 +45,7 @@ class StyleguidePreviewRenderer extends StandardContentPreviewRenderer
             'typo3styleguide_fonts' => $this->renderFontsPreview($row),
             'typo3styleguide_icons' => $this->renderIconsPreview($row),
             'typo3styleguide_images' => $this->renderImagesPreview($row),
+            'typo3styleguide_tableofcontents' => $this->renderTableOfContentsPreview($row),
             default => parent::renderPageModulePreviewContent($item),
         };
     }
@@ -169,6 +170,22 @@ class StyleguidePreviewRenderer extends StandardContentPreviewRenderer
         }
 
         return $this->renderFluidPreview('Images', ['images' => $images]);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function renderTableOfContentsPreview(array $row): string
+    {
+        $layout = (string) ($row['tx_typo3styleguide_tableofcontents_layout'] ?? 'list');
+        $layoutLabels = [
+            'list' => 'List',
+            'cards' => 'Cards',
+        ];
+
+        return $this->renderFluidPreview('TableOfContents', [
+            'layout' => $layoutLabels[$layout] ?? $layout,
+        ]);
     }
 
     /**

--- a/Classes/UserFunc/CTypeItemsProcFunc.php
+++ b/Classes/UserFunc/CTypeItemsProcFunc.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_styleguide" TYPO3 CMS extension.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\Styleguide\UserFunc;
+
+/**
+ * CTypeItemsProcFunc.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-2.0-or-later
+ */
+class CTypeItemsProcFunc
+{
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function getItems(array &$params): void
+    {
+        $ctypeItems = $GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'] ?? [];
+
+        foreach ($ctypeItems as $item) {
+            $label = (string) ($item['label'] ?? '');
+            $value = (string) ($item['value'] ?? '');
+
+            if ('' === $value || '--div--' === $value) {
+                continue;
+            }
+
+            $params['items'][] = [
+                'label' => $label,
+                'value' => $value,
+                'icon' => (string) ($item['icon'] ?? ''),
+            ];
+        }
+    }
+}

--- a/Classes/ViewHelpers/CTypeIconIdentifierViewHelper.php
+++ b/Classes/ViewHelpers/CTypeIconIdentifierViewHelper.php
@@ -18,8 +18,6 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 /**
  * CTypeIconIdentifierViewHelper.
  *
- * Resolves a CType identifier to its registered icon identifier.
- *
  * @author Konrad Michalik <km@move-elevator.de>
  * @license GPL-2.0-or-later
  */

--- a/Classes/ViewHelpers/CTypeIconIdentifierViewHelper.php
+++ b/Classes/ViewHelpers/CTypeIconIdentifierViewHelper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_styleguide" TYPO3 CMS extension.
+ *
+ * (c) 2025-2026 Konrad Michalik <km@move-elevator.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MoveElevator\Styleguide\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * CTypeIconIdentifierViewHelper.
+ *
+ * Resolves a CType identifier to its registered icon identifier.
+ *
+ * @author Konrad Michalik <km@move-elevator.de>
+ * @license GPL-2.0-or-later
+ */
+class CTypeIconIdentifierViewHelper extends AbstractViewHelper
+{
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('ctype', 'string', 'CType identifier', true);
+    }
+
+    public function render(): string
+    {
+        $ctype = (string) $this->arguments['ctype'];
+        if ('' === $ctype) {
+            return '';
+        }
+
+        return (string) ($GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes'][$ctype] ?? '');
+    }
+}

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -42,4 +42,8 @@ return [
         'provider' => SvgIconProvider::class,
         'source' => 'EXT:typo3_styleguide/Resources/Public/Icons/content-styleguide-images.svg',
     ],
+    'content-styleguide-tableofcontents' => [
+        'provider' => SvgIconProvider::class,
+        'source' => 'EXT:typo3_styleguide/Resources/Public/Icons/content-styleguide-tableofcontents.svg',
+    ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -62,6 +62,6 @@ $GLOBALS['TCA']['pages']['columns']['tx_typo3styleguide_ctype_icon'] = [
                 'value' => '',
             ],
         ],
-        'itemsProcFunc' => \MoveElevator\Styleguide\UserFunc\CTypeItemsProcFunc::class.'->getItems',
+        'itemsProcFunc' => MoveElevator\Styleguide\UserFunc\CTypeItemsProcFunc::class.'->getItems',
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -43,8 +43,25 @@ ArrayUtility::mergeRecursiveWithOverrule(
         ],
         'types' => [
             Configuration::PAGE_TYPE => [
-                'showitem' => $GLOBALS['TCA']['pages']['types'][PageRepository::DOKTYPE_DEFAULT]['showitem'],
+                'showitem' => $GLOBALS['TCA']['pages']['types'][PageRepository::DOKTYPE_DEFAULT]['showitem']
+                    .',--div--;LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:page.styleguide,tx_typo3styleguide_ctype_icon',
             ],
         ],
     ],
 );
+
+$GLOBALS['TCA']['pages']['columns']['tx_typo3styleguide_ctype_icon'] = [
+    'label' => 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:page.styleguide.ctype_icon',
+    'config' => [
+        'type' => 'select',
+        'renderType' => 'selectSingle',
+        'default' => '',
+        'items' => [
+            [
+                'label' => '',
+                'value' => '',
+            ],
+        ],
+        'itemsProcFunc' => \MoveElevator\Styleguide\UserFunc\CTypeItemsProcFunc::class.'->getItems',
+    ],
+];

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -89,11 +89,26 @@ ExtensionManagementUtility::addTcaSelectItem(
     'after',
 );
 
+// --- Table of Contents ---
+ExtensionManagementUtility::addTcaSelectItem(
+    'tt_content',
+    'CType',
+    [
+        'label' => $lll.'contentelement.tableofcontents.label',
+        'value' => 'typo3styleguide_tableofcontents',
+        'icon' => 'content-styleguide-tableofcontents',
+        'description' => $lll.'contentelement.tableofcontents.description',
+    ],
+    'typo3styleguide_images',
+    'after',
+);
+
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_technicalheadline'] = 'content-styleguide-headline';
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_colors'] = 'content-styleguide-colors';
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_fonts'] = 'content-styleguide-fonts';
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_icons'] = 'content-styleguide-icons';
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_images'] = 'content-styleguide-images';
+$GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['typo3styleguide_tableofcontents'] = 'content-styleguide-tableofcontents';
 
 $GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
     $GLOBALS['TCA']['tt_content']['columns'],
@@ -181,6 +196,24 @@ $GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
                     'useSortable' => true,
                     'enabledControls' => [
                         'dragdrop' => true,
+                    ],
+                ],
+            ],
+        ],
+        'tx_typo3styleguide_tableofcontents_layout' => [
+            'label' => $lll.'contentelement.tableofcontents.layout',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'default' => 'list',
+                'items' => [
+                    [
+                        'label' => $lll.'contentelement.tableofcontents.layout.list',
+                        'value' => 'list',
+                    ],
+                    [
+                        'label' => $lll.'contentelement.tableofcontents.layout.cards',
+                        'value' => 'cards',
                     ],
                 ],
             ],
@@ -277,6 +310,25 @@ $GLOBALS['TCA']['tt_content']['types']['typo3styleguide_images'] = [
     'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;general,
                     --palette--;;header,tx_typo3styleguide_images,
+                --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
+                    --palette--;;frames,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,
+                    --palette--;;language,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
+                    --palette--;;hidden,
+                    --palette--;;access,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:categories,
+                    categories,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:notes,
+                    rowDescription,
+                --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended,',
+];
+
+$GLOBALS['TCA']['tt_content']['types']['typo3styleguide_tableofcontents'] = [
+    'previewRenderer' => StyleguidePreviewRenderer::class,
+    'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
+                    --palette--;;general,
+                    --palette--;;header,tx_typo3styleguide_tableofcontents_layout,
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
                     --palette--;;frames,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,

--- a/Configuration/TsConfig/ContentElements/TableOfContents.tsconfig
+++ b/Configuration/TsConfig/ContentElements/TableOfContents.tsconfig
@@ -1,0 +1,15 @@
+mod.wizards.newContentElement.wizardItems {
+  styleguide {
+    elements {
+      typo3styleguide_tableofcontents {
+        iconIdentifier = content-styleguide-tableofcontents
+        title = LLL:EXT:typo3_styleguide/Resources/Private/Language/locallang.xlf:contentelement.tableofcontents.label
+        description = LLL:EXT:typo3_styleguide/Resources/Private/Language/locallang.xlf:contentelement.tableofcontents.description
+        tt_content_defValues {
+          CType = typo3styleguide_tableofcontents
+        }
+      }
+    }
+    show := addToList(typo3styleguide_tableofcontents)
+  }
+}

--- a/Configuration/TsConfig/TCEFORM.tsconfig
+++ b/Configuration/TsConfig/TCEFORM.tsconfig
@@ -41,3 +41,7 @@
   mod.wizards.newContentElement.wizardItems.styleguide.show >
   TCEFORM.tt_content.CType.removeItems := addToList(typo3styleguide_technicalheadline,typo3styleguide_colors,typo3styleguide_fonts,typo3styleguide_icons,typo3styleguide_images)
 [end]
+
+[traverse(page, "doktype") != 1754310721]
+  TCEFORM.pages.tx_typo3styleguide_ctype_icon.disabled = 1
+[end]

--- a/Configuration/TsConfig/TCEFORM.tsconfig
+++ b/Configuration/TsConfig/TCEFORM.tsconfig
@@ -39,7 +39,7 @@
 
 [traverse(page, "doktype") != 1754310721]
   mod.wizards.newContentElement.wizardItems.styleguide.show >
-  TCEFORM.tt_content.CType.removeItems := addToList(typo3styleguide_technicalheadline,typo3styleguide_colors,typo3styleguide_fonts,typo3styleguide_icons,typo3styleguide_images)
+  TCEFORM.tt_content.CType.removeItems := addToList(typo3styleguide_technicalheadline,typo3styleguide_colors,typo3styleguide_fonts,typo3styleguide_icons,typo3styleguide_images,typo3styleguide_tableofcontents)
 [end]
 
 [traverse(page, "doktype") != 1754310721]

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -63,7 +63,6 @@ tt_content {
       includeSpacer = 1
       as = pages
       expandAll = 1
-      additionalFields = tx_typo3styleguide_ctype_icon,doktype
     }
   }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,6 @@
 lib.contentElement {
   templateRootPaths.1722340760 = EXT:typo3_styleguide/Resources/Private/Templates/
+  partialRootPaths.1722340760 = EXT:typo3_styleguide/Resources/Private/Partials/
 }
 tt_content {
   typo3styleguide_technicalheadline =< lib.contentElement
@@ -48,6 +49,21 @@ tt_content {
       markers.uid.field = uid
       orderBy = sorting
       as = images
+    }
+  }
+
+  typo3styleguide_tableofcontents =< lib.contentElement
+  typo3styleguide_tableofcontents {
+    templateName = TableOfContents
+    dataProcessing.10 = TYPO3\CMS\Frontend\DataProcessing\MenuProcessor
+    dataProcessing.10 {
+      special = directory
+      special.value.data = TSFE:id
+      levels = 9
+      includeSpacer = 1
+      as = pages
+      expandAll = 1
+      additionalFields = tx_typo3styleguide_ctype_icon,doktype
     }
   }
 }

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -147,6 +147,30 @@
 				<source />
 				<target>Bildunterschrift</target>
 			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.label">
+				<source />
+				<target>Inhaltsverzeichnis</target>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.description">
+				<source />
+				<target>Navigierbares Inhaltsverzeichnis der untergeordneten Styleguide-Seiten anzeigen</target>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout">
+				<source />
+				<target>Layout</target>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout.list">
+				<source />
+				<target>Liste</target>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout.cards">
+				<source />
+				<target>Karten</target>
+			</trans-unit>
+			<trans-unit id="page.styleguide.ctype_icon">
+				<source />
+				<target>Repräsentatives Inhaltselement</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -111,6 +111,24 @@
 			<trans-unit id="tx_typo3styleguide_image.caption">
 				<source>Caption</source>
 			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.label">
+				<source>Table of contents</source>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.description">
+				<source>Display a navigable table of contents of child styleguide pages</source>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout">
+				<source>Layout</source>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout.list">
+				<source>List</source>
+			</trans-unit>
+			<trans-unit id="contentelement.tableofcontents.layout.cards">
+				<source>Cards</source>
+			</trans-unit>
+			<trans-unit id="page.styleguide.ctype_icon">
+				<source>Representative content element</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/TableOfContents/Cards.html
+++ b/Resources/Private/Partials/TableOfContents/Cards.html
@@ -1,0 +1,31 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+    xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<div class="typo3-styleguide-toc__cards">
+    <f:for each="{pages}" as="page">
+        <f:if condition="{page.data.doktype} == 1754310721">
+            <a href="{page.link}" class="typo3-styleguide-toc__card">
+                <f:if condition="{page.data.tx_typo3styleguide_ctype_icon}">
+                    <span class="typo3-styleguide-toc__card-icon">
+                        <core:icon identifier="{sg:cTypeIconIdentifier(ctype: page.data.tx_typo3styleguide_ctype_icon)}" size="large" />
+                    </span>
+                </f:if>
+                <span class="typo3-styleguide-toc__card-title">{page.title}</span>
+            </a>
+        </f:if>
+    </f:for>
+</div>
+
+<f:for each="{pages}" as="page">
+    <f:if condition="{page.data.doktype} == 1754310721">
+        <f:if condition="{page.children}">
+            <f:render partial="TableOfContents/Cards" arguments="{pages: page.children}" />
+        </f:if>
+    </f:if>
+</f:for>
+
+</html>

--- a/Resources/Private/Partials/TableOfContents/Cards.html
+++ b/Resources/Private/Partials/TableOfContents/Cards.html
@@ -23,7 +23,10 @@
 <f:for each="{pages}" as="page">
     <f:if condition="{page.data.doktype} == 1754310721">
         <f:if condition="{page.children}">
-            <f:render partial="TableOfContents/Cards" arguments="{pages: page.children}" />
+            <div class="typo3-styleguide-toc__group">
+                <h3 class="typo3-styleguide-toc__group-title">{page.title}</h3>
+                <f:render partial="TableOfContents/Cards" arguments="{pages: page.children}" />
+            </div>
         </f:if>
     </f:if>
 </f:for>

--- a/Resources/Private/Partials/TableOfContents/Cards.html
+++ b/Resources/Private/Partials/TableOfContents/Cards.html
@@ -11,7 +11,7 @@
             <a href="{page.link}" class="typo3-styleguide-toc__card">
                 <f:if condition="{page.data.tx_typo3styleguide_ctype_icon}">
                     <span class="typo3-styleguide-toc__card-icon">
-                        <core:icon identifier="{sg:cTypeIconIdentifier(ctype: page.data.tx_typo3styleguide_ctype_icon)}" size="large" />
+                        <core:icon identifier="{sg:cTypeIconIdentifier(ctype: page.data.tx_typo3styleguide_ctype_icon)}" size="default" />
                     </span>
                 </f:if>
                 <span class="typo3-styleguide-toc__card-title">{page.title}</span>

--- a/Resources/Private/Partials/TableOfContents/List.html
+++ b/Resources/Private/Partials/TableOfContents/List.html
@@ -1,0 +1,19 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<ul class="typo3-styleguide-toc__list">
+    <f:for each="{pages}" as="page">
+        <f:if condition="{page.data.doktype} == 1754310721">
+            <li class="typo3-styleguide-toc__item">
+                <a href="{page.link}" class="typo3-styleguide-toc__link">{page.title}</a>
+                <f:if condition="{page.children}">
+                    <f:render partial="TableOfContents/List" arguments="{pages: page.children}" />
+                </f:if>
+            </li>
+        </f:if>
+    </f:for>
+</ul>
+
+</html>

--- a/Resources/Private/Templates/Preview/TableOfContents.html
+++ b/Resources/Private/Templates/Preview/TableOfContents.html
@@ -1,0 +1,4 @@
+<div style="padding:4px 8px;">
+    <span style="font-weight:bold;">Layout:</span>
+    <span>{layout}</span>
+</div>

--- a/Resources/Private/Templates/Preview/TableOfContents.html
+++ b/Resources/Private/Templates/Preview/TableOfContents.html
@@ -1,4 +1,4 @@
 <div style="padding:4px 8px;">
-    <span style="font-weight:bold;">Layout:</span>
+    <span style="font-weight:bold;">Layout: </span>
     <span>{layout}</span>
 </div>

--- a/Resources/Private/Templates/TableOfContents.html
+++ b/Resources/Private/Templates/TableOfContents.html
@@ -3,6 +3,9 @@
     data-namespace-typo3-fluid="true"
 >
 
+<f:asset.css identifier="typo3styleguide_element_css" href="EXT:typo3_styleguide/Resources/Public/Css/Patterns.css"/>
+<f:asset.css identifier="typo3styleguide_toc_css" href="EXT:typo3_styleguide/Resources/Public/Css/TableOfContents.css"/>
+
 <f:if condition="{pages}">
     <nav class="typo3-styleguide-toc typo3-styleguide-toc--{data.tx_typo3styleguide_tableofcontents_layout}">
         <f:switch expression="{data.tx_typo3styleguide_tableofcontents_layout}">

--- a/Resources/Private/Templates/TableOfContents.html
+++ b/Resources/Private/Templates/TableOfContents.html
@@ -1,0 +1,19 @@
+<html
+    xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+    data-namespace-typo3-fluid="true"
+>
+
+<f:if condition="{pages}">
+    <nav class="typo3-styleguide-toc typo3-styleguide-toc--{data.tx_typo3styleguide_tableofcontents_layout}">
+        <f:switch expression="{data.tx_typo3styleguide_tableofcontents_layout}">
+            <f:case value="cards">
+                <f:render partial="TableOfContents/Cards" arguments="{pages: pages}" />
+            </f:case>
+            <f:defaultCase>
+                <f:render partial="TableOfContents/List" arguments="{pages: pages}" />
+            </f:defaultCase>
+        </f:switch>
+    </nav>
+</f:if>
+
+</html>

--- a/Resources/Public/Css/TableOfContents.css
+++ b/Resources/Public/Css/TableOfContents.css
@@ -90,7 +90,7 @@
     font-family: monospace, sans-serif;
     font-size: 0.95rem;
     text-align: center;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* --- Cards Sub-Groups (deeper levels) --- */

--- a/Resources/Public/Css/TableOfContents.css
+++ b/Resources/Public/Css/TableOfContents.css
@@ -1,0 +1,128 @@
+.typo3-styleguide-toc {
+    font-family: monospace, sans-serif;
+    margin: 0 40px;
+}
+
+/* --- List Layout --- */
+
+.typo3-styleguide-toc__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.typo3-styleguide-toc__list .typo3-styleguide-toc__list {
+    margin-left: 2rem;
+    margin-top: 0.25rem;
+}
+
+.typo3-styleguide-toc__item {
+    list-style: none;
+}
+
+.typo3-styleguide-toc__item::before {
+    content: '# ';
+    color: var(--typo3-sg-text-secondary, #646464);
+}
+
+.typo3-styleguide-toc__link {
+    display: inline-flex;
+    min-width: 10rem;
+    padding: 0.25rem 0;
+    text-decoration-style: dotted;
+    text-decoration-color: var(--typo3-sg-text-secondary, #646464);
+    color: var(--typo3-sg-text-primary, #000000);
+}
+
+.typo3-styleguide-toc__link:hover {
+    color: var(--typo3-sg-accent, #f49700);
+    text-decoration-color: var(--typo3-sg-accent, #f49700);
+}
+
+/* --- Cards Layout --- */
+
+.typo3-styleguide-toc__cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 24px;
+    padding: 10px 0;
+}
+
+.typo3-styleguide-toc__card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 32px 20px 24px;
+    border: 1px solid var(--typo3-sg-border, #ddd);
+    border-radius: 10px;
+    background: var(--typo3-sg-bg-primary, #ffffff);
+    text-decoration: none;
+    color: var(--typo3-sg-text-primary, #000000);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.typo3-styleguide-toc__card:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    color: var(--typo3-sg-text-primary, #000000);
+}
+
+.typo3-styleguide-toc__card-icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 48px;
+    height: 48px;
+}
+
+.typo3-styleguide-toc__card-icon img,
+.typo3-styleguide-toc__card-icon svg {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+}
+
+.typo3-styleguide-toc__card-title {
+    font-family: monospace, sans-serif;
+    font-size: 0.95rem;
+    text-align: center;
+    word-break: break-word;
+}
+
+/* --- Responsive --- */
+
+@media (max-width: 768px) {
+    .typo3-styleguide-toc {
+        margin: 0 20px;
+    }
+
+    .typo3-styleguide-toc__cards {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 16px;
+    }
+}
+
+@media (max-width: 480px) {
+    .typo3-styleguide-toc {
+        margin: 0 16px;
+    }
+
+    .typo3-styleguide-toc__cards {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 12px;
+    }
+
+    .typo3-styleguide-toc__card {
+        padding: 20px 16px 16px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .typo3-styleguide-toc__card {
+        transition: none;
+    }
+}

--- a/Resources/Public/Css/TableOfContents.css
+++ b/Resources/Public/Css/TableOfContents.css
@@ -93,6 +93,26 @@
     word-break: break-word;
 }
 
+/* --- Cards Sub-Groups (deeper levels) --- */
+
+.typo3-styleguide-toc__group {
+    margin-top: 2rem;
+    padding-left: 1rem;
+    border-left: 2px solid var(--typo3-sg-border, #ddd);
+}
+
+.typo3-styleguide-toc__group-title {
+    font-family: monospace, sans-serif;
+    font-size: 1.1rem;
+    font-weight: normal;
+    color: var(--typo3-sg-text-secondary, #646464);
+    margin: 0 0 0.5rem;
+}
+
+.typo3-styleguide-toc__group-title::before {
+    content: '# ';
+}
+
 /* --- Responsive --- */
 
 @media (max-width: 768px) {

--- a/Resources/Public/Icons/content-styleguide-tableofcontents.svg
+++ b/Resources/Public/Icons/content-styleguide-tableofcontents.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="8" y="10" width="48" height="6" rx="1" fill="#697689"/>
+  <rect x="14" y="22" width="42" height="4" rx="1" fill="#697689" opacity="0.6"/>
+  <rect x="14" y="32" width="42" height="4" rx="1" fill="#697689" opacity="0.6"/>
+  <rect x="14" y="42" width="42" height="4" rx="1" fill="#697689" opacity="0.6"/>
+  <circle cx="10" cy="24" r="2" fill="#697689"/>
+  <circle cx="10" cy="34" r="2" fill="#697689"/>
+  <circle cx="10" cy="44" r="2" fill="#697689"/>
+  <rect x="20" y="52" width="36" height="3" rx="1" fill="#697689" opacity="0.4"/>
+</svg>

--- a/Tests/Acceptance/Fixtures/data.xml
+++ b/Tests/Acceptance/Fixtures/data.xml
@@ -23,6 +23,17 @@
                 <node index="subrow" type="array">
                     <node index="2" type="array">
                         <uid>2</uid>
+                        <node index="subrow" type="array">
+                            <node index="3" type="array">
+                                <uid>3</uid>
+                            </node>
+                            <node index="4" type="array">
+                                <uid>4</uid>
+                            </node>
+                            <node index="5" type="array">
+                                <uid>5</uid>
+                            </node>
+                        </node>
                     </node>
                 </node>
             </node>
@@ -40,6 +51,27 @@
                     <uid>2</uid>
                     <pid>1</pid>
                     <title>Styleguide</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="3" type="array">
+                    <uid>3</uid>
+                    <pid>2</pid>
+                    <title>Text</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="4" type="array">
+                    <uid>4</uid>
+                    <pid>2</pid>
+                    <title>Lists &amp; Tables</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="5" type="array">
+                    <uid>5</uid>
+                    <pid>2</pid>
+                    <title>Media</title>
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
@@ -154,6 +186,83 @@
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
+                <rec index="13" type="array">
+                    <uid>13</uid>
+                    <pid>2</pid>
+                    <title>Content Elements</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="14" type="array">
+                    <uid>14</uid>
+                    <pid>2</pid>
+                    <title>Overview</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="15" type="array">
+                    <uid>15</uid>
+                    <pid>3</pid>
+                    <title>Text Elements</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="16" type="array">
+                    <uid>16</uid>
+                    <pid>3</pid>
+                    <title>Simple Text</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="17" type="array">
+                    <uid>17</uid>
+                    <pid>3</pid>
+                    <title>Text with Media</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="18" type="array">
+                    <uid>18</uid>
+                    <pid>4</pid>
+                    <title>Lists and Tables</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="19" type="array">
+                    <uid>19</uid>
+                    <pid>4</pid>
+                    <title>Bullet List</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="20" type="array">
+                    <uid>20</uid>
+                    <pid>4</pid>
+                    <title>Data Table</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="21" type="array">
+                    <uid>21</uid>
+                    <pid>5</pid>
+                    <title>Media Elements</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="22" type="array">
+                    <uid>22</uid>
+                    <pid>5</pid>
+                    <title>File Downloads</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="23" type="array">
+                    <uid>23</uid>
+                    <pid>5</pid>
+                    <title>Raw HTML</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
             </table>
             <table index="tx_typo3styleguide_color" type="array">
                 <rec index="1" type="array">
@@ -246,6 +355,8 @@
                     <item index="6">1</item>
                     <item index="7">1</item>
                     <item index="8">1</item>
+                    <item index="13">1</item>
+                    <item index="14">1</item>
                 </table>
                 <table index="tx_typo3styleguide_color" type="array">
                     <item index="1">1</item>
@@ -260,6 +371,32 @@
                 <table index="tx_typo3styleguide_image" type="array">
                     <item index="1">1</item>
                     <item index="2">1</item>
+                </table>
+                <table index="pages" type="array">
+                    <item index="3">1</item>
+                    <item index="4">1</item>
+                    <item index="5">1</item>
+                </table>
+            </page_contents>
+            <page_contents index="3" type="array">
+                <table index="tt_content" type="array">
+                    <item index="15">1</item>
+                    <item index="16">1</item>
+                    <item index="17">1</item>
+                </table>
+            </page_contents>
+            <page_contents index="4" type="array">
+                <table index="tt_content" type="array">
+                    <item index="18">1</item>
+                    <item index="19">1</item>
+                    <item index="20">1</item>
+                </table>
+            </page_contents>
+            <page_contents index="5" type="array">
+                <table index="tt_content" type="array">
+                    <item index="21">1</item>
+                    <item index="22">1</item>
+                    <item index="23">1</item>
                 </table>
             </page_contents>
         </pid_lookup>
@@ -1564,6 +1701,1129 @@ page.100 {
                 <field index="parenttable">tt_content</field>
                 <field index="path">EXT:core/Resources/Public/Images/typo3_black.svg</field>
                 <field index="caption">TYPO3 Logo Black</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:13" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">13</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">2</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">3328</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Content Elements</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:14" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">14</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">2</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">3584</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_tableofcontents</field>
+                <field index="header">Overview</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_tableofcontents_layout">cards</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="pages:3" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">3</field>
+                <field index="pid" type="integer">2</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group">0</field>
+                <field index="sorting" type="integer">256</field>
+                <field index="rowDescription" type="NULL"></field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l10n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l10n_diffsource">{&quot;hidden&quot;:&quot;&quot;}</field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="perms_userid" type="integer">1</field>
+                <field index="perms_groupid" type="integer">0</field>
+                <field index="perms_user" type="integer">31</field>
+                <field index="perms_group" type="integer">27</field>
+                <field index="perms_everybody" type="integer">0</field>
+                <field index="title">Text</field>
+                <field index="doktype" type="integer">1754310721</field>
+                <field index="TSconfig" type="NULL"></field>
+                <field index="is_siteroot" type="integer">0</field>
+                <field index="php_tree_stop" type="integer">0</field>
+                <field index="url"></field>
+                <field index="shortcut" type="integer">0</field>
+                <field index="shortcut_mode" type="integer">0</field>
+                <field index="subtitle"></field>
+                <field index="layout" type="integer">0</field>
+                <field index="target"></field>
+                <field index="media" type="integer">0</field>
+                <field index="keywords" type="NULL"></field>
+                <field index="cache_timeout" type="integer">0</field>
+                <field index="cache_tags"></field>
+                <field index="description" type="NULL"></field>
+                <field index="no_search" type="integer">0</field>
+                <field index="SYS_LASTCHANGED" type="integer">0</field>
+                <field index="abstract" type="NULL"></field>
+                <field index="module"></field>
+                <field index="extendToSubpages" type="integer">0</field>
+                <field index="author"></field>
+                <field index="author_email"></field>
+                <field index="nav_title"></field>
+                <field index="nav_hide" type="integer">0</field>
+                <field index="content_from_pid" type="integer">0</field>
+                <field index="mount_pid" type="integer">0</field>
+                <field index="mount_pid_ol" type="integer">0</field>
+                <field index="l18n_cfg" type="integer">0</field>
+                <field index="backend_layout"></field>
+                <field index="backend_layout_next_level"></field>
+                <field index="tsconfig_includes" type="NULL"></field>
+                <field index="categories" type="integer">0</field>
+                <field index="lastUpdated" type="integer">0</field>
+                <field index="newUntil" type="integer">0</field>
+                <field index="slug">/styleguide/text</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="seo_title"></field>
+                <field index="no_index" type="integer">0</field>
+                <field index="no_follow" type="integer">0</field>
+                <field index="og_title"></field>
+                <field index="og_description" type="NULL"></field>
+                <field index="og_image" type="integer">0</field>
+                <field index="twitter_title"></field>
+                <field index="twitter_description" type="NULL"></field>
+                <field index="twitter_image" type="integer">0</field>
+                <field index="twitter_card">summary</field>
+                <field index="canonical_link"></field>
+                <field index="sitemap_priority">0.5</field>
+                <field index="sitemap_changefreq"></field>
+                <field index="tx_typo3styleguide_ctype_icon">text</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="pages:4" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">4</field>
+                <field index="pid" type="integer">2</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group">0</field>
+                <field index="sorting" type="integer">512</field>
+                <field index="rowDescription" type="NULL"></field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l10n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l10n_diffsource">{&quot;hidden&quot;:&quot;&quot;}</field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="perms_userid" type="integer">1</field>
+                <field index="perms_groupid" type="integer">0</field>
+                <field index="perms_user" type="integer">31</field>
+                <field index="perms_group" type="integer">27</field>
+                <field index="perms_everybody" type="integer">0</field>
+                <field index="title">Lists &amp; Tables</field>
+                <field index="doktype" type="integer">1754310721</field>
+                <field index="TSconfig" type="NULL"></field>
+                <field index="is_siteroot" type="integer">0</field>
+                <field index="php_tree_stop" type="integer">0</field>
+                <field index="url"></field>
+                <field index="shortcut" type="integer">0</field>
+                <field index="shortcut_mode" type="integer">0</field>
+                <field index="subtitle"></field>
+                <field index="layout" type="integer">0</field>
+                <field index="target"></field>
+                <field index="media" type="integer">0</field>
+                <field index="keywords" type="NULL"></field>
+                <field index="cache_timeout" type="integer">0</field>
+                <field index="cache_tags"></field>
+                <field index="description" type="NULL"></field>
+                <field index="no_search" type="integer">0</field>
+                <field index="SYS_LASTCHANGED" type="integer">0</field>
+                <field index="abstract" type="NULL"></field>
+                <field index="module"></field>
+                <field index="extendToSubpages" type="integer">0</field>
+                <field index="author"></field>
+                <field index="author_email"></field>
+                <field index="nav_title"></field>
+                <field index="nav_hide" type="integer">0</field>
+                <field index="content_from_pid" type="integer">0</field>
+                <field index="mount_pid" type="integer">0</field>
+                <field index="mount_pid_ol" type="integer">0</field>
+                <field index="l18n_cfg" type="integer">0</field>
+                <field index="backend_layout"></field>
+                <field index="backend_layout_next_level"></field>
+                <field index="tsconfig_includes" type="NULL"></field>
+                <field index="categories" type="integer">0</field>
+                <field index="lastUpdated" type="integer">0</field>
+                <field index="newUntil" type="integer">0</field>
+                <field index="slug">/styleguide/lists-tables</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="seo_title"></field>
+                <field index="no_index" type="integer">0</field>
+                <field index="no_follow" type="integer">0</field>
+                <field index="og_title"></field>
+                <field index="og_description" type="NULL"></field>
+                <field index="og_image" type="integer">0</field>
+                <field index="twitter_title"></field>
+                <field index="twitter_description" type="NULL"></field>
+                <field index="twitter_image" type="integer">0</field>
+                <field index="twitter_card">summary</field>
+                <field index="canonical_link"></field>
+                <field index="sitemap_priority">0.5</field>
+                <field index="sitemap_changefreq"></field>
+                <field index="tx_typo3styleguide_ctype_icon">bullets</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="pages:5" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">5</field>
+                <field index="pid" type="integer">2</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group">0</field>
+                <field index="sorting" type="integer">768</field>
+                <field index="rowDescription" type="NULL"></field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l10n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l10n_diffsource">{&quot;hidden&quot;:&quot;&quot;}</field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="perms_userid" type="integer">1</field>
+                <field index="perms_groupid" type="integer">0</field>
+                <field index="perms_user" type="integer">31</field>
+                <field index="perms_group" type="integer">27</field>
+                <field index="perms_everybody" type="integer">0</field>
+                <field index="title">Media</field>
+                <field index="doktype" type="integer">1754310721</field>
+                <field index="TSconfig" type="NULL"></field>
+                <field index="is_siteroot" type="integer">0</field>
+                <field index="php_tree_stop" type="integer">0</field>
+                <field index="url"></field>
+                <field index="shortcut" type="integer">0</field>
+                <field index="shortcut_mode" type="integer">0</field>
+                <field index="subtitle"></field>
+                <field index="layout" type="integer">0</field>
+                <field index="target"></field>
+                <field index="media" type="integer">0</field>
+                <field index="keywords" type="NULL"></field>
+                <field index="cache_timeout" type="integer">0</field>
+                <field index="cache_tags"></field>
+                <field index="description" type="NULL"></field>
+                <field index="no_search" type="integer">0</field>
+                <field index="SYS_LASTCHANGED" type="integer">0</field>
+                <field index="abstract" type="NULL"></field>
+                <field index="module"></field>
+                <field index="extendToSubpages" type="integer">0</field>
+                <field index="author"></field>
+                <field index="author_email"></field>
+                <field index="nav_title"></field>
+                <field index="nav_hide" type="integer">0</field>
+                <field index="content_from_pid" type="integer">0</field>
+                <field index="mount_pid" type="integer">0</field>
+                <field index="mount_pid_ol" type="integer">0</field>
+                <field index="l18n_cfg" type="integer">0</field>
+                <field index="backend_layout"></field>
+                <field index="backend_layout_next_level"></field>
+                <field index="tsconfig_includes" type="NULL"></field>
+                <field index="categories" type="integer">0</field>
+                <field index="lastUpdated" type="integer">0</field>
+                <field index="newUntil" type="integer">0</field>
+                <field index="slug">/styleguide/media</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="seo_title"></field>
+                <field index="no_index" type="integer">0</field>
+                <field index="no_follow" type="integer">0</field>
+                <field index="og_title"></field>
+                <field index="og_description" type="NULL"></field>
+                <field index="og_image" type="integer">0</field>
+                <field index="twitter_title"></field>
+                <field index="twitter_description" type="NULL"></field>
+                <field index="twitter_image" type="integer">0</field>
+                <field index="twitter_card">summary</field>
+                <field index="canonical_link"></field>
+                <field index="sitemap_priority">0.5</field>
+                <field index="sitemap_changefreq"></field>
+                <field index="tx_typo3styleguide_ctype_icon">image</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:15" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">15</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">256</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">header</field>
+                <field index="header">Text Elements</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:16" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">16</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">text</field>
+                <field index="header">Simple Text</field>
+                <field index="header_position"></field>
+                <field index="bodytext">&lt;p&gt;Lorem ipsum dolor sit amet.&lt;/p&gt;</field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:17" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">17</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">768</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">textmedia</field>
+                <field index="header">Text with Media</field>
+                <field index="header_position"></field>
+                <field index="bodytext">&lt;p&gt;Text with media example.&lt;/p&gt;</field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:18" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">18</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">4</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">256</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">header</field>
+                <field index="header">Lists and Tables</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:19" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">19</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">4</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">bullets</field>
+                <field index="header">Bullet List</field>
+                <field index="header_position"></field>
+                <field index="bodytext">Item 1
+Item 2
+Item 3</field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:20" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">20</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">4</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">768</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">table</field>
+                <field index="header">Data Table</field>
+                <field index="header_position"></field>
+                <field index="bodytext">Header 1|Header 2|Header 3
+Cell 1|Cell 2|Cell 3
+Cell 4|Cell 5|Cell 6</field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:21" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">21</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">5</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">256</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">header</field>
+                <field index="header">Media Elements</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:22" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">22</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">5</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">uploads</field>
+                <field index="header">File Downloads</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:23" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">23</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">5</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">768</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">html</field>
+                <field index="header">Raw HTML</field>
+                <field index="header_position"></field>
+                <field index="bodytext">&lt;div class=&quot;custom-element&quot;&gt;Custom HTML content&lt;/div&gt;</field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>

--- a/Tests/Acceptance/Fixtures/data.xml
+++ b/Tests/Acceptance/Fixtures/data.xml
@@ -263,6 +263,48 @@
                     <relations index="rels" type="array"></relations>
                     <softrefs type="array"></softrefs>
                 </rec>
+                <rec index="24" type="array">
+                    <uid>24</uid>
+                    <pid>3</pid>
+                    <title>Simple Text</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="25" type="array">
+                    <uid>25</uid>
+                    <pid>3</pid>
+                    <title>Text with Media</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="26" type="array">
+                    <uid>26</uid>
+                    <pid>4</pid>
+                    <title>Bullet List</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="27" type="array">
+                    <uid>27</uid>
+                    <pid>4</pid>
+                    <title>Data Table</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="28" type="array">
+                    <uid>28</uid>
+                    <pid>5</pid>
+                    <title>File Downloads</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
+                <rec index="29" type="array">
+                    <uid>29</uid>
+                    <pid>5</pid>
+                    <title>Raw HTML</title>
+                    <relations index="rels" type="array"></relations>
+                    <softrefs type="array"></softrefs>
+                </rec>
             </table>
             <table index="tx_typo3styleguide_color" type="array">
                 <rec index="1" type="array">
@@ -381,21 +423,27 @@
             <page_contents index="3" type="array">
                 <table index="tt_content" type="array">
                     <item index="15">1</item>
+                    <item index="24">1</item>
                     <item index="16">1</item>
+                    <item index="25">1</item>
                     <item index="17">1</item>
                 </table>
             </page_contents>
             <page_contents index="4" type="array">
                 <table index="tt_content" type="array">
                     <item index="18">1</item>
+                    <item index="26">1</item>
                     <item index="19">1</item>
+                    <item index="27">1</item>
                     <item index="20">1</item>
                 </table>
             </page_contents>
             <page_contents index="5" type="array">
                 <table index="tt_content" type="array">
                     <item index="21">1</item>
+                    <item index="28">1</item>
                     <item index="22">1</item>
+                    <item index="29">1</item>
                     <item index="23">1</item>
                 </table>
             </page_contents>
@@ -2136,7 +2184,7 @@ page.100 {
                 <field index="t3ver_wsid" type="integer">0</field>
                 <field index="t3ver_state" type="integer">0</field>
                 <field index="t3ver_stage" type="integer">0</field>
-                <field index="CType">header</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
                 <field index="header">Text Elements</field>
                 <field index="header_position"></field>
                 <field index="bodytext"></field>
@@ -2203,7 +2251,7 @@ page.100 {
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">512</field>
+                <field index="sorting" type="integer">768</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2282,7 +2330,7 @@ page.100 {
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">768</field>
+                <field index="sorting" type="integer">1280</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2373,7 +2421,7 @@ page.100 {
                 <field index="t3ver_wsid" type="integer">0</field>
                 <field index="t3ver_state" type="integer">0</field>
                 <field index="t3ver_stage" type="integer">0</field>
-                <field index="CType">header</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
                 <field index="header">Lists and Tables</field>
                 <field index="header_position"></field>
                 <field index="bodytext"></field>
@@ -2440,7 +2488,7 @@ page.100 {
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">512</field>
+                <field index="sorting" type="integer">768</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2521,7 +2569,7 @@ Item 3</field>
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">768</field>
+                <field index="sorting" type="integer">1280</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2614,7 +2662,7 @@ Cell 4|Cell 5|Cell 6</field>
                 <field index="t3ver_wsid" type="integer">0</field>
                 <field index="t3ver_state" type="integer">0</field>
                 <field index="t3ver_stage" type="integer">0</field>
-                <field index="CType">header</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
                 <field index="header">Media Elements</field>
                 <field index="header_position"></field>
                 <field index="bodytext"></field>
@@ -2681,7 +2729,7 @@ Cell 4|Cell 5|Cell 6</field>
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">512</field>
+                <field index="sorting" type="integer">768</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2760,7 +2808,7 @@ Cell 4|Cell 5|Cell 6</field>
                 <field index="starttime" type="integer">0</field>
                 <field index="endtime" type="integer">0</field>
                 <field index="fe_group"></field>
-                <field index="sorting" type="integer">768</field>
+                <field index="sorting" type="integer">1280</field>
                 <field index="editlock" type="integer">0</field>
                 <field index="sys_language_uid" type="integer">0</field>
                 <field index="l18n_parent" type="integer">0</field>
@@ -2824,6 +2872,480 @@ Cell 4|Cell 5|Cell 6</field>
                 <field index="date" type="integer">0</field>
                 <field index="tx_impexp_origuid" type="integer">0</field>
                 <field index="tx_typo3styleguide_technicalheadlinetag">h2</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:24" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">24</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Simple Text</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:25" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">25</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">3</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">1024</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Text with Media</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:26" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">26</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">4</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Bullet List</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:27" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">27</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">4</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">1024</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Data Table</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:28" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">28</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">5</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">512</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">File Downloads</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
+            </fieldlist>
+            <related index="rels" type="array"></related>
+        </tablerow>
+        <tablerow index="tt_content:29" type="array">
+            <fieldlist index="data" type="array">
+                <field index="uid" type="integer">29</field>
+                <field index="rowDescription"></field>
+                <field index="pid" type="integer">5</field>
+                <field index="tstamp" type="integer">1754036171</field>
+                <field index="crdate" type="integer">1754036171</field>
+                <field index="deleted" type="integer">0</field>
+                <field index="hidden" type="integer">0</field>
+                <field index="starttime" type="integer">0</field>
+                <field index="endtime" type="integer">0</field>
+                <field index="fe_group"></field>
+                <field index="sorting" type="integer">1024</field>
+                <field index="editlock" type="integer">0</field>
+                <field index="sys_language_uid" type="integer">0</field>
+                <field index="l18n_parent" type="integer">0</field>
+                <field index="l10n_source" type="integer">0</field>
+                <field index="l10n_state" type="NULL"></field>
+                <field index="t3_origuid" type="integer">0</field>
+                <field index="l18n_diffsource"></field>
+                <field index="t3ver_oid" type="integer">0</field>
+                <field index="t3ver_wsid" type="integer">0</field>
+                <field index="t3ver_state" type="integer">0</field>
+                <field index="t3ver_stage" type="integer">0</field>
+                <field index="CType">typo3styleguide_technicalheadline</field>
+                <field index="header">Raw HTML</field>
+                <field index="header_position"></field>
+                <field index="bodytext"></field>
+                <field index="bullets_type" type="integer">0</field>
+                <field index="uploads_description" type="integer">0</field>
+                <field index="uploads_type" type="integer">0</field>
+                <field index="assets" type="integer">0</field>
+                <field index="image" type="integer">0</field>
+                <field index="imagewidth" type="integer">0</field>
+                <field index="imageorient" type="integer">0</field>
+                <field index="imagecols" type="integer">2</field>
+                <field index="imageborder" type="integer">0</field>
+                <field index="media" type="integer">0</field>
+                <field index="layout" type="integer">0</field>
+                <field index="frame_class">default</field>
+                <field index="cols" type="integer">0</field>
+                <field index="space_before_class"></field>
+                <field index="space_after_class"></field>
+                <field index="records" type="NULL"></field>
+                <field index="pages" type="NULL"></field>
+                <field index="colPos" type="integer">0</field>
+                <field index="subheader"></field>
+                <field index="header_link"></field>
+                <field index="image_zoom" type="integer">0</field>
+                <field index="header_layout">0</field>
+                <field index="list_type"></field>
+                <field index="sectionIndex" type="integer">1</field>
+                <field index="linkToTop" type="integer">0</field>
+                <field index="file_collections" type="NULL"></field>
+                <field index="filelink_size" type="integer">0</field>
+                <field index="filelink_sorting"></field>
+                <field index="filelink_sorting_direction"></field>
+                <field index="target"></field>
+                <field index="recursive" type="integer">0</field>
+                <field index="imageheight" type="integer">0</field>
+                <field index="pi_flexform" type="NULL"></field>
+                <field index="accessibility_title"></field>
+                <field index="accessibility_bypass" type="integer">0</field>
+                <field index="accessibility_bypass_text"></field>
+                <field index="category_field"></field>
+                <field index="table_class"></field>
+                <field index="table_caption" type="NULL"></field>
+                <field index="table_delimiter" type="integer">124</field>
+                <field index="table_enclosure" type="integer">0</field>
+                <field index="table_header_position" type="integer">0</field>
+                <field index="table_tfoot" type="integer">0</field>
+                <field index="categories" type="integer">0</field>
+                <field index="selected_categories" type="NULL"></field>
+                <field index="date" type="integer">0</field>
+                <field index="tx_impexp_origuid" type="integer">0</field>
+                <field index="tx_typo3styleguide_technicalheadlinetag">h3</field>
             </fieldlist>
             <related index="rels" type="array"></related>
         </tablerow>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -5,6 +5,7 @@ CREATE TABLE tt_content
 	tx_typo3styleguide_fonts int(11) unsigned DEFAULT 0 NOT NULL,
 	tx_typo3styleguide_icons_path varchar(255) DEFAULT '' NOT NULL,
 	tx_typo3styleguide_images int(11) unsigned DEFAULT 0 NOT NULL,
+	tx_typo3styleguide_tableofcontents_layout varchar(10) DEFAULT 'list' NOT NULL,
 );
 
 CREATE TABLE tx_typo3styleguide_color
@@ -30,4 +31,9 @@ CREATE TABLE tx_typo3styleguide_image
 	parenttable varchar(255) DEFAULT '' NOT NULL,
 	path varchar(255) DEFAULT '' NOT NULL,
 	caption varchar(255) DEFAULT '' NOT NULL,
+);
+
+CREATE TABLE pages
+(
+	tx_typo3styleguide_ctype_icon varchar(255) DEFAULT '' NOT NULL,
 );


### PR DESCRIPTION
## Summary

- Add new content element `typo3styleguide_tableofcontents` with two layout variants (list, cards)
- Add page property `tx_typo3styleguide_ctype_icon` for selecting a representative CType icon per Styleguide page
- Add `CTypeIconIdentifierViewHelper` to resolve CType identifiers to icon identifiers in Fluid
- Add `CTypeItemsProcFunc` to populate CType select field from TCA
- Add styled CSS matching the existing Styleguide design system (dark mode, responsive)
- Cards layout supports grouped sub-levels with parent page title
- Add test fixtures with TOC element, child Styleguide pages, and Technical Headlines
- Add German translations for all new labels

## Changes

- `ext_tables.sql` — New fields: `tx_typo3styleguide_tableofcontents_layout` (tt_content), `tx_typo3styleguide_ctype_icon` (pages)
- `Configuration/TCA/Overrides/tt_content.php` — Register CType, layout select field, type config
- `Configuration/TCA/Overrides/pages.php` — CType icon select field with itemsProcFunc, Styleguide tab
- `Classes/UserFunc/CTypeItemsProcFunc.php` — Populates select with all registered CTypes
- `Classes/ViewHelpers/CTypeIconIdentifierViewHelper.php` — Resolves CType to icon identifier
- `Classes/Preview/StyleguidePreviewRenderer.php` — Backend preview for TOC element
- `Configuration/TypoScript/setup.typoscript` — MenuProcessor rendering, partialRootPaths
- `Resources/Private/Templates/TableOfContents.html` — Main template with layout dispatch
- `Resources/Private/Partials/TableOfContents/List.html` — Recursive nested list
- `Resources/Private/Partials/TableOfContents/Cards.html` — Card grid with icon and grouped sub-levels
- `Resources/Public/Css/TableOfContents.css` — Styling consistent with Styleguide design system
- `Configuration/TsConfig/` — Wizard entry, TCEFORM restrictions
- `Configuration/Icons.php` — Icon registration
- `Resources/Private/Language/` — EN + DE labels
- `Tests/Acceptance/Fixtures/data.xml` — Fixtures with TOC, child pages, Technical Headlines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Table of Contents content element with List and Cards layouts, backend form control, preview, and wizard integration.
  * New page-level field for selecting a representative content element icon and a view helper to resolve icons.
  * Frontend templates/partials and TypoScript handling for rendering navigable TOC output.

* **Chores**
  * Added CSS styling for TOC layouts, updated TCA/TSConfig, and database schema entries for new fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->