### PR TITLE
feat: add styleguide content element group registration to avoid null…

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -19,6 +19,13 @@ defined('TYPO3') || exit('Access denied.');
 
 $lll = 'LLL:EXT:'.Configuration::EXT_KEY.'/Resources/Private/Language/locallang.xlf:';
 
+ExtensionManagementUtility::addTcaSelectItemGroup(
+    'tt_content',
+    'CType',
+    'styleguide',
+    $lll.'wizard.tab.styleguide',
+);
+
 // --- Technical Headline ---
 ExtensionManagementUtility::addTcaSelectItem(
     'tt_content',
@@ -28,6 +35,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_technicalheadline',
         'icon' => 'content-styleguide-headline',
         'description' => $lll.'contentelement.technical_headline.description',
+        'group' => 'styleguide',
     ],
     'html',
     'after',
@@ -42,6 +50,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_colors',
         'icon' => 'content-styleguide-colors',
         'description' => $lll.'contentelement.colors.description',
+        'group' => 'styleguide',
     ],
     'typo3styleguide_technicalheadline',
     'after',
@@ -56,6 +65,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_fonts',
         'icon' => 'content-styleguide-fonts',
         'description' => $lll.'contentelement.fonts.description',
+        'group' => 'styleguide',
     ],
     'typo3styleguide_colors',
     'after',
@@ -70,6 +80,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_icons',
         'icon' => 'content-styleguide-icons',
         'description' => $lll.'contentelement.icons.description',
+        'group' => 'styleguide',
     ],
     'typo3styleguide_fonts',
     'after',
@@ -84,6 +95,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_images',
         'icon' => 'content-styleguide-images',
         'description' => $lll.'contentelement.images.description',
+        'group' => 'styleguide',
     ],
     'typo3styleguide_icons',
     'after',
@@ -98,6 +110,7 @@ ExtensionManagementUtility::addTcaSelectItem(
         'value' => 'typo3styleguide_tableofcontents',
         'icon' => 'content-styleguide-tableofcontents',
         'description' => $lll.'contentelement.tableofcontents.description',
+        'group' => 'styleguide',
     ],
     'typo3styleguide_images',
     'after',


### PR DESCRIPTION
… pointer deprecation inside ContentStatisticsService

<img width="1744" height="898" alt="image" src="https://github.com/user-attachments/assets/0c6bc42d-130e-4b8c-a1f5-ab60b12a1e11" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new grouping system that organizes styleguide-related content elements in the backend editor, improving discoverability and usability when selecting content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->