### PR TITLE
fix: prevent v14 "page is not valid" condition error for styleguide robots meta

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -67,6 +67,8 @@ tt_content {
   }
 }
 
-[traverse(page, "doktype") == 1754310721]
-  page.meta.robots = noindex,nofollow
-[end]
+page.meta.robots = noindex,nofollow
+page.meta.robots.if {
+  value.data = page:doktype
+  isInList = 1754310721
+}


### PR DESCRIPTION
## Summary

- Resolves #44: on TYPO3 v14 the `[traverse(page, "doktype") == …]` setup condition repeatedly threw `SyntaxError: Variable "page" is not valid` (ERROR-level log noise), and the `noindex,nofollow` rule was silently skipped.
- Root cause: Symfony ExpressionLanguage validates variable names at *parse* time. The include-tree condition matcher only registers `page` when the calling factory passes one; any page-less setup-TypoScript build (non-standard callers) fails to parse the whole expression.
- Fix: drop the include-tree condition entirely and scope the robots meta with a render-time stdWrap `if`/`isInList` guard on `page:doktype`. No condition is parsed during include-tree builds, so it cannot fail in any caller context (v12/v13/v14).

## Verified (local v14, `.Build/14`)

- Styleguide page → `<meta name="robots" content="noindex,nofollow">`
- Regular page → no robots meta (scoping intact)
- v14 log → no `is not valid` parse errors

## Note

The `TCEFORM.tsconfig` conditions are left unchanged: they run as Page TSconfig, where `PageTsConfigFactory` always registers `page` (empty when off-page), so they never parse-fail.

## Changes

- `Configuration/TypoScript/setup.typoscript` - replace `[traverse(page, "doktype")]` condition with a stdWrap `if` guard on the robots meta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized conditional logic for search engine indexing configuration by restructuring the metadata rules application based on page type classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->