### PR TITLE
docs: update security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+> [!CAUTION]
+> **Please avoid using GitHub issues to report security vulnerabilities.**
+
+If you have found a potential security flaw, please reach out directly to the [TYPO3 Security Team](https://typo3.community/contribute/teams-committees/security). For additional information and guidelines, you can also check out [TYPO3's Security Policy](https://github.com/TYPO3/typo3/blob/main/SECURITY.md).


### PR DESCRIPTION
Updates `SECURITY.md` to direct vulnerability reports to the TYPO3 Security Team instead of GitHub issues.