### PR TITLE
fix: declare inline child tables as workspace aware

### DIFF
--- a/Configuration/TCA/tx_typo3styleguide_color.php
+++ b/Configuration/TCA/tx_typo3styleguide_color.php
@@ -20,6 +20,7 @@ return [
         'crdate' => 'crdate',
         'delete' => 'deleted',
         'sortby' => 'sorting',
+        'versioningWS' => true,
         'iconfile' => 'EXT:core/Resources/Public/Icons/T3Icons/svgs/content/content-text.svg',
         'hideTable' => true,
         'enablecolumns' => [

--- a/Configuration/TCA/tx_typo3styleguide_font.php
+++ b/Configuration/TCA/tx_typo3styleguide_font.php
@@ -20,6 +20,7 @@ return [
         'crdate' => 'crdate',
         'delete' => 'deleted',
         'sortby' => 'sorting',
+        'versioningWS' => true,
         'iconfile' => 'EXT:core/Resources/Public/Icons/T3Icons/svgs/content/content-text.svg',
         'hideTable' => true,
         'enablecolumns' => [

--- a/Configuration/TCA/tx_typo3styleguide_image.php
+++ b/Configuration/TCA/tx_typo3styleguide_image.php
@@ -20,6 +20,7 @@ return [
         'crdate' => 'crdate',
         'delete' => 'deleted',
         'sortby' => 'sorting',
+        'versioningWS' => true,
         'iconfile' => 'EXT:core/Resources/Public/Icons/T3Icons/svgs/content/content-image.svg',
         'hideTable' => true,
         'enablecolumns' => [


### PR DESCRIPTION
## Summary

- Resolve TYPO3 v14 TCA migration warnings for inline child tables used in workspace-aware `tt_content`
- Explicitly mark the color, font, and image child tables as workspace aware

## Background

In TYPO3 v14, inline child tables of a workspace-aware parent (`tt_content`) must explicitly declare `'versioningWS' => true` in their `ctrl` section. Without it, the TCA migration emits warnings in the backend. Setting the flag also makes the schema analyzer add the required workspace columns (`t3ver_oid`, `t3ver_wsid`, `t3ver_state`, `t3ver_stage`).

## Changes

- `Configuration/TCA/tx_typo3styleguide_color.php` - Add `versioningWS` to ctrl
- `Configuration/TCA/tx_typo3styleguide_font.php` - Add `versioningWS` to ctrl
- `Configuration/TCA/tx_typo3styleguide_image.php` - Add `versioningWS` to ctrl

## Note

Run `typo3 database:updateschema` after deploying to create the workspace columns.