### PR TITLE
chore(ci): adopt gitleaks and scorecard workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   release:
     uses: konradmichalik/reusable-github-actions/.github/workflows/release.yml@main
+    permissions:
+      contents: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,17 @@
+name: OpenSSF Scorecard
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  scorecard:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,12 @@
+name: Security
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+jobs:
+  security:
+    uses: konradmichalik/reusable-github-actions/.github/workflows/security.yml@main
+    permissions:
+      contents: read

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Supported TYPO3 versions](https://badgen.net/badge/TYPO3/12%20&%2013%20&%2014/orange)](https://extensions.typo3.org/extension/typo3_styleguide)
 [![CGL](https://img.shields.io/github/actions/workflow/status/move-elevator/typo3-styleguide/cgl.yml?label=cgl&logo=github)](https://github.com/move-elevator/typo3-styleguide/actions/workflows/cgl.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/move-elevator/typo3-styleguide/badge)](https://securityscorecards.dev/viewer/?uri=github.com/move-elevator/typo3-styleguide)
 [![License](https://poser.pugx.org/move-elevator/typo3-styleguide/license)](LICENSE.md)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 [![Supported TYPO3 versions](https://badgen.net/badge/TYPO3/12%20&%2013%20&%2014/orange)](https://extensions.typo3.org/extension/typo3_styleguide)
 [![CGL](https://img.shields.io/github/actions/workflow/status/move-elevator/typo3-styleguide/cgl.yml?label=cgl&logo=github)](https://github.com/move-elevator/typo3-styleguide/actions/workflows/cgl.yml)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/move-elevator/typo3-styleguide/badge)](https://securityscorecards.dev/viewer/?uri=github.com/move-elevator/typo3-styleguide)
 [![License](https://poser.pugx.org/move-elevator/typo3-styleguide/license)](LICENSE.md)
 
 </div>


### PR DESCRIPTION
## Summary
- Add gitleaks secret scanning via the shared reusable workflow
- Add OpenSSF Scorecard supply-chain scoring via the shared reusable workflow
- Grant `contents: write` to the release workflow caller (required once the repo's default token is read-only)

These changes bring this repository in line with the security hardening recently added to konradmichalik/reusable-github-actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security and code quality checks to run on pushes, pull requests, scheduled intervals, and manual runs.
  * Added an OpenSSF Scorecard workflow for ongoing repository security assessment.
* **Chores**
  * Updated release automation permissions to support publishing changes more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->